### PR TITLE
Update stratum-bf build

### DIFF
--- a/Jenkinsfiles/Jenkinsfile-stratum-bf-build.groovy
+++ b/Jenkinsfiles/Jenkinsfile-stratum-bf-build.groovy
@@ -4,7 +4,6 @@ BUILD_NODE: p4-dev
 DOCKER_REGISTRY_IP: 10.128.13.253
 DOCKER_REGISTRY_PORT: 5000
 SDE_VERSION: 8.9.2
-KERNEL_VERSION: 4.14.49
 BAZEL_DISK_CACHE: /home/sdn/bazel-disk-cache
 */
 
@@ -19,19 +18,34 @@ pipeline {
         stage('Build') {
             steps {
                 step([$class: 'WsCleanup'])
-                sh returnStdout: false, label: "Start building stratum-bf:bf-sde-${SDE_VERSION}-linux-${KERNEL_VERSION}-OpenNetworkLinux", script: """
+                sh returnStdout: false, label: "Start building stratum-bf:${SDE_VERSION}", script: """
                     git clone https://github.com/stratum/stratum.git
                     cd ${WORKSPACE}/stratum
                     cd ${WORKSPACE}/stratum/stratum/hal/bin/barefoot/docker
-                    ./build-stratum-bf-container.sh /var/jenkins/stratum-contents/bf-sde-${SDE_VERSION}.tgz /var/jenkins/stratum-contents/linux-${KERNEL_VERSION}-OpenNetworkLinux.tar.xz
-                    docker tag stratumproject/stratum-bf:bf-sde-${SDE_VERSION}-linux-${KERNEL_VERSION}-OpenNetworkLinux ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux
-                    docker push ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux
+                    if [ -f /var/jenkins/stratum-contents/bf-sde-${SDE_VERSION}-install.tgz ]; then
+                        SDE_INSTALL_TAR=/var/jenkins/stratum-contents/bf-sde-${SDE_VERSION}-install.tgz \
+                            ./build-stratum-bf-container.sh
+                    else
+                        ./build-stratum-bf-container.sh /var/jenkins/stratum-contents/bf-sde-${SDE_VERSION}.tgz \
+                            /var/jenkins/stratum-contents/linux-3.16.56-OpenNetworkLinux.tar.xz \
+                            /var/jenkins/stratum-contents/linux-4.9.75-OpenNetworkLinux.tar.xz \
+                            /var/jenkins/stratum-contents/linux-4.14.49-OpenNetworkLinux.tar.xz
+                    fi
+
+
                 """
             }
         }
+        stage('Push to local registry') {
+            sh returnStdout: false, label: "Push stratum-bf:${SDE_VERSION} to local registry", script: """
+                docker tag stratumproject/stratum-bf:${SDE_VERSION} \
+                    ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}
+                docker push ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}
+            """
+        }
         stage('Unit Test') {
             steps {
-                sh returnStdout: false, label: "Run unit tests for stratum-bf:${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux", script: """
+                sh returnStdout: false, label: "Run unit tests for stratum-bf:${SDE_VERSION}", script: """
                     cd ${WORKSPACE}/stratum/
                     sed -i '1i build --disk_cache=/tmp/bazel-disk-cache' .bazelrc
                     sed -i '1i startup --output_user_root=/tmp/bazel-cache/output-root' .bazelrc

--- a/Jenkinsfiles/Jenkinsfile-stratum-bf.groovy
+++ b/Jenkinsfiles/Jenkinsfile-stratum-bf.groovy
@@ -18,7 +18,7 @@ pipeline {
                 axes {
                     axis {
                         name 'SDE_VERSION'
-                        values '8.9.2', '9.0.0', '9.1.0', '9.2.0', '9.3.0'
+                        values '9.1.0', '9.2.0', '9.3.0'
                     }
                 }
                 agent {

--- a/Jenkinsfiles/Jenkinsfile-stratum-bf.groovy
+++ b/Jenkinsfiles/Jenkinsfile-stratum-bf.groovy
@@ -18,12 +18,7 @@ pipeline {
                 axes {
                     axis {
                         name 'SDE_VERSION'
-                        values '8.9.2', '9.0.0', '9.2.0'
-                    }
-                    axis {
-                        name 'KERNEL_VERSION'
-                        //values '3.16.56', '4.9.75', '4.14.49'
-                        values '4.14.49'
+                        values '8.9.2', '9.0.0', '9.1.0', '9.2.0', '9.3.0'
                     }
                 }
                 agent {
@@ -31,34 +26,30 @@ pipeline {
                 }
                 stages {
                     stage("Build") {
-                        when { expression { KERNEL_VERSION == '4.14.49' } }
                         steps {
-                            sh returnStdout: false, label: "Start building stratum-bf:${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux", script: ""
+                            sh returnStdout: false, label: "Start building stratum-bf:${SDE_VERSION}", script: ""
                             build job: "stratum-bf-build", parameters: [
                                 string(name: 'SDE_VERSION', value: "${SDE_VERSION}"),
-                                string(name: 'KERNEL_VERSION', value: "${KERNEL_VERSION}"),
                                 string(name: 'DOCKER_REGISTRY_IP', value: "${DOCKER_REGISTRY_IP}"),
                                 string(name: 'DOCKER_REGISTRY_PORT', value: "${DOCKER_REGISTRY_PORT}"),
                             ]
                         }
                     }
                     stage('Test') {
-                        when { expression { KERNEL_VERSION == '4.14.49' } }
                         steps {
-                            sh returnStdout: false, label: "Start testing ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux", script: ""
+                            sh returnStdout: false, label: "Start testing ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}", script: ""
                             build job: "stratum-bf-test-combined", parameters: [
                                 string(name: 'DOCKER_IMAGE', value: "${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf"),
-                                string(name: 'DOCKER_IMAGE_TAG', value: "${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux"),
+                                string(name: 'DOCKER_IMAGE_TAG', value: "${SDE_VERSION}"),
                             ]
                         }
                     }
                     stage('Publish') {
-                        when { expression { KERNEL_VERSION == '4.14.49' } }
                         steps {
-                            sh returnStdout: false, label: "Start publishing ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux", script: ""
+                            sh returnStdout: false, label: "Start publishing ${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf:${SDE_VERSION}", script: ""
                             build job: "stratum-publish", parameters: [
                                 string(name: 'DOCKER_IMAGE', value: "${DOCKER_REGISTRY_IP}:${DOCKER_REGISTRY_PORT}/stratum-bf"),
-                                string(name: 'DOCKER_IMAGE_TAG', value: "${SDE_VERSION}-${KERNEL_VERSION}-OpenNetworkLinux"),
+                                string(name: 'DOCKER_IMAGE_TAG', value: "${SDE_VERSION}"),
                             ]
                         }
                     }

--- a/resources/barefoot/start-stratum-container.sh
+++ b/resources/barefoot/start-stratum-container.sh
@@ -30,9 +30,8 @@ fi
 
 LOG_DIR=${LOG_DIR:-/var/log}
 SDE_VERSION=${SDE_VERSION:-9.0.0}
-KERNEL_VERSION=$(uname -r)
 DOCKER_IMAGE=${DOCKER_IMAGE:-stratumproject/stratum-bf}
-DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-$SDE_VERSION-$KERNEL_VERSION}
+DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-$SDE_VERSION}
 
 docker run -it --rm --privileged \
     --name stratum \


### PR DESCRIPTION
 - Include all kernel versions to a single image
 - Use new image tag (without kernel name)
 - Add 9.1.0 and 9.3.0 since they are both LTS version
 - Use prebuilt SDE tarball to reduce build time