### PR TITLE
Update stratum-bf jobs to build and publish to Dockerhub

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -27,6 +27,7 @@
     aws-s3-credential: 'AKIAR6Z4ESHHIXKSMOXU'
     aether-registry-credential: 'aether-registry-credentials'
     onf-registry-credential: 'onf-registry-credentials'
+    onf-docker-hub-credential: 'onf_docker_hub'
 
     # by default, don't depend on other jobs
     dependency-jobs: ''

--- a/jjb/pipeline/stratum-bf.groovy
+++ b/jjb/pipeline/stratum-bf.groovy
@@ -20,7 +20,6 @@ pipeline {
             steps {
                 sh returnStdout: false, label: "Start building stratum-${TARGET}:${SDE_VERSION}", script: """
                     git clone https://github.com/stratum/stratum.git
-                    cd ${WORKSPACE}/stratum
                     cd ${WORKSPACE}/stratum/stratum/hal/bin/barefoot/docker
                     STRATUM_TARGET=stratum_${TARGET} SDE_INSTALL_TAR=${WORKSPACE}/${SDE_TAR} RELEASE_BUILD=true ./build-stratum-bf-container.sh
                 """

--- a/jjb/pipeline/stratum-bf.groovy
+++ b/jjb/pipeline/stratum-bf.groovy
@@ -3,47 +3,38 @@ pipeline {
         label "${BUILD_NODE}"
     }
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
+        withAWS(credentials:"${AWS_S3_CREDENTIAL}")
+    }
+    environment {
+        SDE_TAR = "bf-sde-${SDE_VERSION}-install.tgz"
     }
     stages {
-		stage("Build") {
-			steps {
-				sh returnStdout: false, label: "Start building stratum-${TARGET}:${SDE_VERSION}", script: ""
-				build job: "stratum-${TARGET}-build", parameters: [
-					string(name: 'SDE_VERSION', value: "${SDE_VERSION}"),
-					string(name: 'KERNEL_VERSION', value: "${KERNEL_VERSION}"),
-					string(name: 'REGISTRY_URL', value: "${REGISTRY_URL}"),
-					string(name: 'REGISTRY_CREDENTIAL', value: "${REGISTRY_CREDENTIAL}"),
-				]
-			}
-		}
-		stage('Test') {
-			steps {
-				sh returnStdout: false, label: "Start testing ${REGISTRY_URL}/stratum-${TARGET}:${SDE_VERSION}", script: ""
-				build job: "stratum-${TARGET}-test-combined", parameters: [
-					string(name: 'REGISTRY_URL', value: "${REGISTRY_URL}"),
-					string(name: 'REGISTRY_CREDENTIAL', value: "${REGISTRY_CREDENTIAL}"),
-					string(name: 'DOCKER_IMAGE', value: "stratum-${TARGET}"),
-					string(name: 'DOCKER_IMAGE_TAG', value: "${SDE_VERSION}"),
-					string(name: 'TARGET', value: "${TARGET}"),
-				]
-			}
-		}
-		stage('Publish') {
-			steps {
-				sh returnStdout: false, label: "Start publishing ${REGISTRY_URL}/stratum-${TARGET}:${SDE_VERSION}", script: ""
-				build job: "stratum-publish", parameters: [
-					string(name: 'REGISTRY_URL', value: "${REGISTRY_URL}"),
-					string(name: 'REGISTRY_CREDENTIAL', value: "${REGISTRY_CREDENTIAL}"),
-					string(name: 'DOCKER_REPOSITORY_NAME', value: "stratum-${TARGET}"),
-					string(name: 'DOCKER_IMAGE_TAG', value: "${SDE_VERSION}"),
-				]
-			}
-		}
-    }
-    /*post {
-        failure {
-            slackSend color: 'danger', message: "Test failed: ${env.JOB_NAME} #${env.BUILD_NUMBER} (<${env.RUN_DISPLAY_URL}|Open>)"
+        stage('Preparations') {
+            steps {
+                step([$class: 'WsCleanup'])
+                s3Download(file:"${SDE_TAR}", bucket:'stratum-artifacts', path:"${SDE_TAR}", force:true)
+            }
         }
-    }*/
+        stage('Build') {
+            steps {
+                sh returnStdout: false, label: "Start building stratum-${TARGET}:${SDE_VERSION}", script: """
+                    git clone https://github.com/stratum/stratum.git
+                    cd ${WORKSPACE}/stratum
+                    cd ${WORKSPACE}/stratum/stratum/hal/bin/barefoot/docker
+                    STRATUM_TARGET=stratum_${TARGET} SDE_INSTALL_TAR=${WORKSPACE}/${SDE_TAR} RELEASE_BUILD=true ./build-stratum-bf-container.sh
+                """
+            }
+        }
+	    stage('Push') {
+	        steps {
+                withDockerRegistry([ credentialsId: "${ONF_DOCKER_HUB_CREDENTIAL}", url: "" ]) {
+                    sh returnStdout: false, label: "Start publishing stratum-${TARGET}:latest-${SDE_VERSION}", script: """
+                        docker tag stratumproject/stratum-${TARGET}:${SDE_VERSION} stratumproject/stratum-${TARGET}:latest-${SDE_VERSION}
+                        docker push stratumproject/stratum-${TARGET}:latest-${SDE_VERSION}
+		            """
+                }
+            }
+        }
+    }
 }

--- a/jjb/repos/stratum-bf.yaml
+++ b/jjb/repos/stratum-bf.yaml
@@ -23,9 +23,6 @@
             build-timeout: 120
             target: 'bf'
             sde-version: '9.5.0'
-        - 'stratum-bf-build':
-            build-timeout: 120
-            target: 'bf'
         - 'stratum-bf-test-combined':
             build-timeout: 120
             target: 'bf'
@@ -54,9 +51,6 @@
             build-timeout: 120
             target: 'bfrt'
             sde-version: '9.5.0'
-        - 'stratum-bf-build':
-            build-timeout: 120
-            target: 'bfrt'
         - 'stratum-bf-test-combined':
             build-timeout: 120
             target: 'bfrt'

--- a/jjb/templates/stratum-bf.yaml
+++ b/jjb/templates/stratum-bf.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
 
 ---
-# Job to trigger stratum bf build, test and publish
+# Job to trigger stratum barefoot target build and publish
 
 - job-template:
     id: stratum-bf
@@ -24,14 +24,9 @@
           description: 'Name of the Jenkins build executor to run the job on'
 
       - string:
-          name: REGISTRY_URL
-          default: 'registry.opennetworking.org/stratum-ccp'
-          description: 'Private registry URL'
-
-      - string:
-          name: REGISTRY_CREDENTIAL
-          default: '{onf-registry-credential}'
-          description: 'Credentials name for docker registry'
+          name: ONF_DOCKER_HUB_CREDENTIAL
+          default: '{onf-docker-hub-credential}'
+          description: 'Credentials name for docker hub'
 
       - string:
           name: TARGET
@@ -47,6 +42,11 @@
           name: KERNEL_VERSION
           default: '4.14.49'
           description: 'Kernel Version'      
+
+      - string:
+          name: AWS_S3_CREDENTIAL
+          default: '{aws-s3-credential}'
+          description: 'Credentials name for AWS S3 bucket'    
 
     triggers:
       - timed: '{once-a-day}'

--- a/jjb/templates/stratum-bf.yaml
+++ b/jjb/templates/stratum-bf.yaml
@@ -39,11 +39,6 @@
           description: 'SDE Version to build'
 
       - string:
-          name: KERNEL_VERSION
-          default: '4.14.49'
-          description: 'Kernel Version'      
-
-      - string:
           name: AWS_S3_CREDENTIAL
           default: '{aws-s3-credential}'
           description: 'Credentials name for AWS S3 bucket'    


### PR DESCRIPTION
This PR modifies stratum-bf and stratum-bfrt jobs to build docker image and directly push to dockerhub with `stratum-bf:latest-<SDE>` and `stratum-bfrt:latest-<SDE>` tags.
This is the first set of jobs from below agreed solution for unified build process:
```Versions:
latest-<SDE_VERSION>: built daily from source for qa and dev
YY.MM.DD-<SDE_VERSION>: tagged weekly for production deployments
<SDE_VERSION>: after CCP verification
YY.MM-<SDE_VERSION>: official release tags; quarterly; after passing CCP
```