### PR TITLE
new jobs to add weekly tag to stratum-bf images

### DIFF
--- a/jjb/pipeline/stratum-bf-add-tag.groovy
+++ b/jjb/pipeline/stratum-bf-add-tag.groovy
@@ -11,7 +11,7 @@ pipeline {
                 step([$class: 'WsCleanup'])
                 script {
                     if(params.DOCKER_IMAGE_TAG == '') {
-                        DOCKER_IMAGE_TAG=sh(script:'date +%y%m%d', returnStdout:true).trim()+"-"+SDE_VERSION
+                        DOCKER_IMAGE_TAG=sh(script:'date +%y.%m.%d', returnStdout:true).trim()+"-"+SDE_VERSION
                     }
                 }
             }

--- a/jjb/pipeline/stratum-bf-add-tag.groovy
+++ b/jjb/pipeline/stratum-bf-add-tag.groovy
@@ -1,0 +1,39 @@
+pipeline {
+    agent {
+        label "${BUILD_NODE}"
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+    }
+    stages {
+        stage('Preparations') {
+            steps {
+                step([$class: 'WsCleanup'])
+                script {
+                    if(params.DOCKER_IMAGE_TAG == '') {
+                        DOCKER_IMAGE_TAG=sh(script:'date +%y%m%d', returnStdout:true).trim()+"-"+SDE_VERSION
+                    }
+                }
+            }
+        }
+        stage('Pull Latest Image') {
+            steps {
+                withDockerRegistry([ credentialsId: "${ONF_REGISTRY_CREDENTIAL}", url: "https://${ONF_REGISTRY_URL}" ]) {
+                    sh returnStdout: false, label: "Pull stratum-${TARGET}:latest-${SDE_VERSION}", script: """
+                        docker pull ${ONF_REGISTRY_URL}/docker.io/stratumproject/stratum-${TARGET}:latest-${SDE_VERSION}
+		            """
+                }
+            }
+        }
+	    stage('Push') {
+	        steps {
+                withDockerRegistry([ credentialsId: "${ONF_DOCKER_HUB_CREDENTIAL}", url: "" ]) {
+                    sh returnStdout: false, label: "Start publishing stratum-${TARGET}:latest-${SDE_VERSION}", script: """
+                        docker tag ${ONF_REGISTRY_URL}/docker.io/stratumproject/stratum-${TARGET}:latest-${SDE_VERSION} stratumproject/stratum-${TARGET}:${DOCKER_IMAGE_TAG}
+                        docker push stratumproject/stratum-${TARGET}:${DOCKER_IMAGE_TAG}
+		            """
+                }
+            }
+        }
+    }
+}

--- a/jjb/pipeline/stratum-bf-add-tag.groovy
+++ b/jjb/pipeline/stratum-bf-add-tag.groovy
@@ -1,39 +1,39 @@
 pipeline {
-    agent {
-        label "${BUILD_NODE}"
-    }
-    options {
-        timeout(time: 60, unit: 'MINUTES')
-    }
-    stages {
-        stage('Preparations') {
-            steps {
-                step([$class: 'WsCleanup'])
-                script {
-                    if(params.DOCKER_IMAGE_TAG == '') {
-                        DOCKER_IMAGE_TAG=sh(script:'date +%y.%m.%d', returnStdout:true).trim()+"-"+SDE_VERSION
-                    }
-                }
-            }
+  agent {
+    label "${BUILD_NODE}"
+  }
+  options {
+    timeout(time: 60, unit: 'MINUTES')
+  }
+  stages {
+    stage('Preparations') {
+      steps {
+        step([$class: 'WsCleanup'])
+        script {
+          if(params.DOCKER_IMAGE_TAG == '') {
+            DOCKER_IMAGE_TAG=sh(script:'date +%y.%m.%d', returnStdout:true).trim()+"-"+SDE_VERSION
+          }
         }
-        stage('Pull Latest Image') {
-            steps {
-                withDockerRegistry([ credentialsId: "${ONF_REGISTRY_CREDENTIAL}", url: "https://${ONF_REGISTRY_URL}" ]) {
-                    sh returnStdout: false, label: "Pull stratum-${TARGET}:latest-${SDE_VERSION}", script: """
-                        docker pull ${ONF_REGISTRY_URL}/docker.io/stratumproject/stratum-${TARGET}:latest-${SDE_VERSION}
-		            """
-                }
-            }
-        }
-	    stage('Push') {
-	        steps {
-                withDockerRegistry([ credentialsId: "${ONF_DOCKER_HUB_CREDENTIAL}", url: "" ]) {
-                    sh returnStdout: false, label: "Start publishing stratum-${TARGET}:latest-${SDE_VERSION}", script: """
-                        docker tag ${ONF_REGISTRY_URL}/docker.io/stratumproject/stratum-${TARGET}:latest-${SDE_VERSION} stratumproject/stratum-${TARGET}:${DOCKER_IMAGE_TAG}
-                        docker push stratumproject/stratum-${TARGET}:${DOCKER_IMAGE_TAG}
-		            """
-                }
-            }
-        }
+      }
     }
+    stage('Pull Latest Image') {
+      steps {
+        withDockerRegistry([ credentialsId: "${ONF_REGISTRY_CREDENTIAL}", url: "https://${ONF_REGISTRY_URL}" ]) {
+          sh returnStdout: false, label: "Pull stratum-${TARGET}:latest-${SDE_VERSION}", script: """
+            docker pull ${ONF_REGISTRY_URL}/docker.io/stratumproject/stratum-${TARGET}:latest-${SDE_VERSION}
+          """
+        }
+      }
+    }
+    stage('Push') {
+      steps {
+        withDockerRegistry([ credentialsId: "${ONF_DOCKER_HUB_CREDENTIAL}", url: "" ]) {
+          sh returnStdout: false, label: "Start publishing stratum-${TARGET}:latest-${SDE_VERSION}", script: """
+            docker tag ${ONF_REGISTRY_URL}/docker.io/stratumproject/stratum-${TARGET}:latest-${SDE_VERSION} stratumproject/stratum-${TARGET}:${DOCKER_IMAGE_TAG}
+            docker push stratumproject/stratum-${TARGET}:${DOCKER_IMAGE_TAG}
+          """
+        }
+      }
+    }
+  }
 }

--- a/jjb/repos/stratum-bf.yaml
+++ b/jjb/repos/stratum-bf.yaml
@@ -23,6 +23,22 @@
             build-timeout: 120
             target: 'bf'
             sde-version: '9.5.0'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bf'
+            sde-version: '9.3.1'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bf'
+            sde-version: '9.3.2'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bf'
+            sde-version: '9.4.0'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bf'
+            sde-version: '9.5.0'
         - 'stratum-bf-test-combined':
             build-timeout: 120
             target: 'bf'
@@ -48,6 +64,22 @@
             target: 'bfrt'
             sde-version: '9.4.0'
         - 'stratum-bf':
+            build-timeout: 120
+            target: 'bfrt'
+            sde-version: '9.5.0'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bfrt'
+            sde-version: '9.3.1'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bfrt'
+            sde-version: '9.3.2'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bfrt'
+            sde-version: '9.4.0'
+        - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bfrt'
             sde-version: '9.5.0'

--- a/jjb/templates/stratum-bf-weekly.yaml
+++ b/jjb/templates/stratum-bf-weekly.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2020 Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+
+---
+# Job to push stratum barefoot weekly image tag
+
+- job-template:
+    id: stratum-bf-weekly
+    name: 'stratum-{target}-{sde-version}-weekly'
+    description: |
+      Created by {id} job-template from ci-management/jjb/stratum-bf-weekly.yaml, script ../pipeline/stratum-bf-add-tag.groovy
+    properties:
+      - onf-infra-properties:
+          build-days-to-keep: '15'
+          artifact-num-to-keep: '15'
+    wrappers:
+      - onf-infra-rsync-wrappers:
+          build-timeout: '{build-timeout}'
+    parameters:
+      - string:
+          name: BUILD_NODE
+          default: '{build-node}'
+          description: 'Name of the Jenkins build executor to run the job on'
+
+      - string:
+          name: ONF_DOCKER_HUB_CREDENTIAL
+          default: '{onf-docker-hub-credential}'
+          description: 'Credentials name for docker hub'
+
+      - string:
+          name: TARGET
+          default: '{target}'
+          description: 'Stratum barefoot target (bf or bfrt)'
+
+      - string:
+          name: SDE_VERSION
+          default: '{sde-version}'
+          description: 'SDE Version to build'   
+
+      - string:
+          name: DOCKER_IMAGE_TAG
+          default: ''
+          description: 'New tag to add to latest image'
+
+      - string:
+          name: ONF_REGISTRY_CREDENTIAL
+          default: 'onf-registry-credentials'
+          description: 'Credentials name for ONF registry'
+
+      - string:
+          name: ONF_REGISTRY_URL
+          default: 'registry.opennetworking.org'
+          description: 'URL for ONF registry'
+
+    triggers:
+      - timed: 'H 0 * * 5'
+
+    project-type: pipeline
+    concurrent: true
+    extraEnvironmentVars: ""
+    sandbox: true
+
+    dsl: !include-raw-escape: ../pipeline/stratum-bf-add-tag.groovy


### PR DESCRIPTION
This PR add new stratum-bf and stratum-bfrt jobs to add weekly tags stratum-bf:latest-<SDE> and stratum-bfrt:latest-<SDE> images.
This is the second set of jobs from below agreed solution for unified build process:

latest-<SDE_VERSION>: built daily from source for qa and dev
**YY.MM.DD-<SDE_VERSION>: tagged weekly for production deployments**
<SDE_VERSION>: after CCP verification
YY.MM-<SDE_VERSION>: official release tags; quarterly; after passing CCP