### PR TITLE
Add git-refs parameter to stratum build jobs

### DIFF
--- a/jjb/pipeline/stratum-bf.groovy
+++ b/jjb/pipeline/stratum-bf.groovy
@@ -20,6 +20,7 @@ pipeline {
             steps {
                 sh returnStdout: false, label: "Start building stratum-${TARGET}:${SDE_VERSION}", script: """
                     git clone https://github.com/stratum/stratum.git
+                    cd ${WORKSPACE}/stratum && git checkout ${GIT_REFS}
                     cd ${WORKSPACE}/stratum/stratum/hal/bin/barefoot/docker
                     STRATUM_TARGET=stratum_${TARGET} SDE_INSTALL_TAR=${WORKSPACE}/${SDE_TAR} RELEASE_BUILD=true ./build-stratum-bf-container.sh
                 """

--- a/jjb/templates/stratum-bf.yaml
+++ b/jjb/templates/stratum-bf.yaml
@@ -41,8 +41,12 @@
       - string:
           name: AWS_S3_CREDENTIAL
           default: '{aws-s3-credential}'
-          description: 'Credentials name for AWS S3 bucket'    
+          description: 'Credentials name for AWS S3 bucket'
 
+      - string:
+          name: GIT_REFS
+          default: 'origin/main'
+          description: 'git commit/ref/branch of Stratum to checkout'
     triggers:
       - timed: '{once-a-day}'
 


### PR DESCRIPTION
To run builds with a specific commit hash or branch, we can use this additional parameter
By default, it will be `origin/main`