### PR TITLE
Stop building stratum-bf with SDE 9.7.0

### DIFF
--- a/jjb/repos/stratum-bf.yaml
+++ b/jjb/repos/stratum-bf.yaml
@@ -23,10 +23,6 @@
             build-timeout: 120
             target: 'bf'
             sde-version: '9.5.0'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.7.0'
         - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bf'
@@ -43,10 +39,6 @@
             build-timeout: 120
             target: 'bf'
             sde-version: '9.5.0'
-        - 'stratum-bf-weekly':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.7.0'
         - 'stratum-bf-test-combined':
             build-timeout: 120
             target: 'bf'


### PR DESCRIPTION
In https://github.com/stratum/stratum/pull/864 we decide to deprecate stratum_bf since SDE 9.7.0