### PR TITLE
Update build targets for Stratum-bf/bfrt

### DIFF
--- a/jjb/repos/stratum-bf.yaml
+++ b/jjb/repos/stratum-bf.yaml
@@ -10,35 +10,19 @@
         - 'stratum-bf':
             build-timeout: 120
             target: 'bf'
-            sde-version: '9.3.1'
+            sde-version: '9.5.0'
         - 'stratum-bf':
             build-timeout: 120
             target: 'bf'
-            sde-version: '9.3.2'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.4.0'
-        - 'stratum-bf':
+            sde-version: '9.5.2'
+        - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bf'
             sde-version: '9.5.0'
         - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bf'
-            sde-version: '9.3.1'
-        - 'stratum-bf-weekly':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.3.2'
-        - 'stratum-bf-weekly':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.4.0'
-        - 'stratum-bf-weekly':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.5.0'
+            sde-version: '9.5.2'
         - 'stratum-bf-test-combined':
             build-timeout: 120
             target: 'bf'
@@ -54,35 +38,23 @@
         - 'stratum-bf':
             build-timeout: 120
             target: 'bfrt'
-            sde-version: '9.3.1'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.3.2'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.4.0'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
             sde-version: '9.5.0'
         - 'stratum-bf':
             build-timeout: 120
             target: 'bfrt'
+            sde-version: '9.5.2'
+        - 'stratum-bf':
+            build-timeout: 120
+            target: 'bfrt'
             sde-version: '9.7.0'
-        - 'stratum-bf-weekly':
+        - 'stratum-bf':
             build-timeout: 120
             target: 'bfrt'
-            sde-version: '9.3.1'
-        - 'stratum-bf-weekly':
+            sde-version: '9.7.1'
+        - 'stratum-bf':
             build-timeout: 120
             target: 'bfrt'
-            sde-version: '9.3.2'
-        - 'stratum-bf-weekly':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.4.0'
+            sde-version: '9.8.0'
         - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bfrt'
@@ -90,7 +62,19 @@
         - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bfrt'
+            sde-version: '9.5.2'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bfrt'
             sde-version: '9.7.0'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bfrt'
+            sde-version: '9.7.1'
+        - 'stratum-bf-weekly':
+            build-timeout: 120
+            target: 'bfrt'
+            sde-version: '9.8.0'
         - 'stratum-bf-test-combined':
             build-timeout: 120
             target: 'bfrt'
@@ -103,4 +87,3 @@
         - 'stratum-bf-p4rt-test':
             build-timeout: 120
             target: 'bfrt'
-


### PR DESCRIPTION
Remove 9.3.1, 9.3.2, and 9.4.0
Add 9.5.2, 9.7.1, and 9.8.0

Wait until https://github.com/stratum/stratum/pull/912 merged.