### PR TITLE
Delete nightly bcm, bf, bfrt builds from Jenkins

### DIFF
--- a/jjb/repos/stratum-bcm.yaml
+++ b/jjb/repos/stratum-bcm.yaml
@@ -7,12 +7,6 @@
     project: '{name}'
     
     jobs:
-        - 'stratum-bcm':
-            build-timeout: 30 
-            target: 'opennsa' 
-        - 'stratum-bcm':
-            build-timeout: 30
-            target: 'sdklt'
         - 'stratum-bcm-weekly':
             build-timeout: 30 
             target: 'opennsa'

--- a/jjb/repos/stratum-bf.yaml
+++ b/jjb/repos/stratum-bf.yaml
@@ -7,14 +7,6 @@
     project: '{name}'
 
     jobs:
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.5.0'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bf'
-            sde-version: '9.5.2'
         - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bf'
@@ -35,26 +27,6 @@
         - 'stratum-bf-p4rt-test':
             build-timeout: 120
             target: 'bf'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.5.0'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.5.2'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.7.0'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.7.1'
-        - 'stratum-bf':
-            build-timeout: 120
-            target: 'bfrt'
-            sde-version: '9.8.0'
         - 'stratum-bf-weekly':
             build-timeout: 120
             target: 'bfrt'


### PR DESCRIPTION
Cleaning nightly build jobs to push docker images from Jenkins as images are now built using CircleCI